### PR TITLE
[Cargo.toml] Upgrade sled

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,6 @@ os_pipe = "0.9.0"
 serde = "1.0.101"
 serde_derive = "1.0.101"
 serde_json = "1.0.41"
-sled = { git = "https://github.com/Fantom-foundation/sled", version = "0.28.3" }
 to_vec = "0.1.0"
 libconsensus = { git = "https://github.com/Fantom-foundation/libconsensus", version="~0.0.8" }
 libtransport = { git = "https://github.com/Fantom-foundation/libtransport", version="~0.0.4" }
@@ -26,6 +25,7 @@ libhash = { git = "https://github.com/Fantom-foundation/libhash" }
 libhash-sha3 = { git = "https://github.com/Fantom-foundation/libhash-sha3", version="~0.1.1" }
 libsignature = { git = "https://github.com/Fantom-foundation/libsignature", version="~0.2.0" }
 failure = "0.1.5"
+sled = "0.29.2"
 
 [dev-dependencies]
 libsignature-ed25519-dalek = { git = "https://github.com/Fantom-foundation/libsignature-ed25519-dalek", version="~0.2.2" }


### PR DESCRIPTION
We no longer use Tokio, so no longer need a [`channel-crossbeam` compatible with Tokio ](https://github.com/Fantom-foundation/sled/commit/e334077e7e43d92a6368773a00978a7182598733)